### PR TITLE
Update GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,15 +8,16 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: read
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/configure-pages@v3
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: frontend
-      - uses: actions/deploy-pages@v1
+      - uses: actions/deploy-pages@v4
         id: deploy


### PR DESCRIPTION
## Summary
- update actions in deploy workflow to the latest major versions
- grant `actions: read` permission required by `deploy-pages@v4`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d6c24379483328154a9591adca936