### PR TITLE
style: adopt apple-inspired theme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,15 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CrossFit WOD Tracker</title>
     <!-- Materialize CSS for quick styling -->
-    <!-- Comment for kicking of a commit, delete later -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
 </head>
 <body class="container">
     <h3 class="center-align">CrossFit WOD Tracker</h3>
 
     <div id="auth-section" class="section">
-        <button id="google-login" class="btn red darken-1">Sign in with Google</button>
-        <button id="facebook-login" class="btn blue darken-4">Sign in with Facebook</button>
+        <button id="google-login" class="btn">Sign in with Google</button>
+        <button id="facebook-login" class="btn">Sign in with Facebook</button>
     </div>
 
     <ul id="tabs" class="tabs">
@@ -29,7 +29,7 @@
         <div class="section">
             <label for="wod-image">Or upload a photo</label>
             <input type="file" id="wod-image" accept="image/*">
-            <div id="ocr-status" class="blue-text"></div>
+            <div id="ocr-status"></div>
         </div>
         <button id="save-wod" class="btn">Save WOD</button>
     </div>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -10,6 +10,10 @@ firebase.initializeApp(firebaseConfig);
 const auth = firebase.auth();
 const db = firebase.firestore();
 
+// Apple-style chart defaults
+Chart.defaults.color = '#1d1d1f';
+Chart.defaults.font.family = '-apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", "Helvetica Neue", Helvetica, Arial, sans-serif';
+
 // Google sign-in
 const googleBtn = document.getElementById('google-login');
 if (googleBtn) {
@@ -125,7 +129,7 @@ function renderChart(labels, data) {
       datasets: [{
         label: 'Workout text length',
         data,
-        borderColor: 'blue',
+        borderColor: '#0071e3',
         fill: false,
       }]
     },

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,62 @@
+/* Apple-inspired theme */
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  background-color: #fff;
+  color: #1d1d1f;
+  margin: 0;
+  padding: 20px;
+}
+
+h3 {
+  font-weight: 600;
+  margin-top: 40px;
+  margin-bottom: 20px;
+}
+
+.btn {
+  background-color: #0071e3;
+  border-radius: 12px;
+  text-transform: none;
+  box-shadow: none;
+}
+
+.btn:hover {
+  background-color: #0077ed;
+}
+
+#auth-section .btn {
+  margin-right: 10px;
+}
+
+.tabs .tab a {
+  color: #0071e3;
+  font-weight: 500;
+}
+
+.tabs .tab a.active {
+  color: #1d1d1f;
+  border-bottom: 2px solid #1d1d1f;
+}
+
+textarea.materialize-textarea {
+  border: 1px solid #d2d2d7;
+  border-radius: 8px;
+  padding: 10px;
+}
+
+label {
+  color: #1d1d1f;
+}
+
+input[type="file"] {
+  margin-top: 10px;
+}
+
+#save-wod {
+  margin-top: 20px;
+}
+
+#ocr-status {
+  color: #0071e3;
+  margin-top: 8px;
+}


### PR DESCRIPTION
## Summary
- Introduce Apple-inspired typography and color scheme via new stylesheet
- Simplify UI elements to match Apple's minimal aesthetic and override Materialize defaults
- Harmonize chart styling with Apple's palette and fonts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689589081ef88332a57ed5c7e13852c5